### PR TITLE
feat(i18n): add language switch and translate homepage to EN

### DIFF
--- a/src/Layout/CommonLayout/Footer.js
+++ b/src/Layout/CommonLayout/Footer.js
@@ -1,52 +1,106 @@
 import React from "react";
-import { Row, Col, Container } from "reactstrap";
 import { Link } from "react-router-dom";
+import { Col, Container, Row } from "reactstrap";
+import { useLanguage } from "../../context/LanguageContext";
 
 const Footer = () => {
-  const footer = [
-    {
-      id: 1,
-      title: "Empresa",
-      menu: [
-        { id: 1, link: "/about", subTitle: "Sobre Nós" },
-        { id: 2, link: "/contact", subTitle: "Fale Conosco" },
-        { id: 3, link: "/services", subTitle: "Serviços" },
-        { id: 4, link: "/blog", subTitle: "Blog" },
-        { id: 5, link: "/team", subTitle: "Equipe" },
-        { id: 6, link: "/pricing", subTitle: "Preços" },
-      ],
-    },
-    {
-      id: 2,
-      title: "Para Candidatos",
-      menu: [
-        { id: 1, link: "/jobscategories", subTitle: "Categorias de Vagas" },
-        { id: 2, link: "/joblist", subTitle: "Listagem de Vagas" },
-        { id: 4, link: "/bookmarkjobs", subTitle: "Vagas Salvas" },
-      ],
-    },
-    {
-      id: 3,
-      title: "Para Recrutadores",
-      menu: [
-        { id: 1, link: "/candidatelist", subTitle: "Lista de Candidatos" },
-        { id: 3, link: "/candidatedetails", subTitle: "Detalhes do Candidato" },
-      ],
-    },
-    {
-      id: 4,
-      title: "Suporte",
-      menu: [
-        { id: 1, link: "/contact", subTitle: "Central de Ajuda" },
-        { id: 2, link: "/faqs", subTitle: "Perguntas Frequentes" },
+  const { language } = useLanguage();
+  const translatedLinks = {
+    pt: {
+      footer: [
+        {
+          id: 1,
+          title: "Empresa",
+          menu: [
+            { id: 1, link: "/about", subTitle: "Sobre Nós" },
+            { id: 2, link: "/contact", subTitle: "Fale Conosco" },
+            { id: 3, link: "/services", subTitle: "Serviços" },
+            { id: 4, link: "/blog", subTitle: "Blog" },
+            { id: 5, link: "/team", subTitle: "Equipe" },
+            { id: 6, link: "/pricing", subTitle: "Preços" },
+          ],
+        },
+        {
+          id: 2,
+          title: "Para Candidatos",
+          menu: [
+            { id: 1, link: "/jobscategories", subTitle: "Categorias de Vagas" },
+            { id: 2, link: "/joblist", subTitle: "Listagem de Vagas" },
+            { id: 4, link: "/bookmarkjobs", subTitle: "Vagas Salvas" },
+          ],
+        },
         {
           id: 3,
-          link: "/privacyandpolicy",
-          subTitle: "Política de Privacidade",
+          title: "Para Recrutadores",
+          menu: [
+            { id: 1, link: "/candidatelist", subTitle: "Lista de Candidatos" },
+            { id: 3, link: "/candidatedetails", subTitle: "Detalhes do Candidato" },
+          ],
         },
-      ],
+        {
+          id: 4,
+          title: "Suporte",
+          menu: [
+            { id: 1, link: "/contact", subTitle: "Central de Ajuda" },
+            { id: 2, link: "/faqs", subTitle: "Perguntas Frequentes" },
+            {
+              id: 3,
+              link: "/privacyandpolicy",
+              subTitle: "Política de Privacidade",
+            },
+          ],
+        },
+      ]
     },
-  ];
+    en: {
+      footer: [
+        {
+          id: 1,
+          title: "Company",
+          menu: [
+            { id: 1, link: "/about", subTitle: "About Us" },
+            { id: 2, link: "/contact", subTitle: "Contact Us" },
+            { id: 3, link: "/services", subTitle: "Services" },
+            { id: 4, link: "/blog", subTitle: "Blog" },
+            { id: 5, link: "/team", subTitle: "Team" },
+            { id: 6, link: "/pricing", subTitle: "Pricing" },
+          ],
+        },
+        {
+          id: 2,
+          title: "For Candidates",
+          menu: [
+            { id: 1, link: "/jobscategories", subTitle: "Job Categories" },
+            { id: 2, link: "/joblist", subTitle: "Job Listings" },
+            { id: 4, link: "/bookmarkjobs", subTitle: "Saved Jobs" },
+          ],
+        },
+        {
+          id: 3,
+          title: "For Recruiters",
+          menu: [
+            { id: 1, link: "/candidatelist", subTitle: "Candidate List" },
+            { id: 3, link: "/candidatedetails", subTitle: "Candidate Details" },
+          ],
+        },
+        {
+          id: 4,
+          title: "Support",
+          menu: [
+            { id: 1, link: "/contact", subTitle: "Help Center" },
+            { id: 2, link: "/faqs", subTitle: "Frequently Asked Questions" },
+            {
+              id: 3,
+              link: "/privacyandpolicy",
+              subTitle: "Privacy Policy",
+            },
+          ],
+        },
+      ]
+
+    }
+  }
+
   const footerIcons = [
     {
       id: 1,
@@ -65,6 +119,8 @@ const Footer = () => {
       socialIcon: "uil uil-twitter",
     },
   ];
+
+  const t = translatedLinks[language] || translatedLinks['pt']
   return (
     <React.Fragment>
       <section className="bg-footer">
@@ -74,10 +130,9 @@ const Footer = () => {
               <div className="footer-item mt-4 mt-lg-0 me-lg-5">
                 <h4 className="text-white mb-4">Recruitment</h4>
                 <p className="text-white-50">
-                  É um fato estabelecido que um leitor se distrairá com o
-                  conteúdo de uma página ao observar seu layout.
+                  {language === 'pt' ? "É um fato estabelecido que um leitor se distrairá com o conteúdo de uma página ao observar seu layout." : "It's an established fact that a reader will be distracted by the content of a page when looking at its layout."}
                 </p>
-                <p className="text-white mt-3">Siga-nos em:</p>
+                <p className="text-white mt-3">{language === 'pt' ? "Siga-nos em" : "Follow us"}:</p>
                 <ul className="footer-social-menu list-inline mb-0">
                   {footerIcons.map((footerIcondetails, key) => (
                     <li className="list-inline-item" key={key}>
@@ -89,7 +144,7 @@ const Footer = () => {
                 </ul>
               </div>
             </Col>
-            {footer.map((footerdetails, key) => (
+            {t.footer.map((footerdetails, key) => (
               <Col lg={2} xs={6} key={key}>
                 <div className="footer-item mt-4 mt-lg-0">
                   <p className="fs-16 text-white mb-4">{footerdetails.title}</p>

--- a/src/Layout/CommonLayout/NavBar.js
+++ b/src/Layout/CommonLayout/NavBar.js
@@ -1,23 +1,25 @@
-import React, { useState, useEffect, useContext, useCallback } from "react";
+import { Icon } from "@iconify/react";
+import classnames from "classnames";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { Button } from "react-bootstrap";
+import { Link, useLocation } from "react-router-dom";
 import {
-  Container,
   Collapse,
+  Container,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
   NavbarToggler,
   NavItem,
   NavLink,
-  Dropdown,
-  DropdownToggle,
-  DropdownMenu,
-  DropdownItem,
 } from "reactstrap";
-import { Link, useLocation } from "react-router-dom";
-import classnames from "classnames";
-import { Icon } from "@iconify/react";
-import { Button } from "react-bootstrap";
 
 import darkLogo from "../../assets/images/dark-logo.png";
 import lightLogo from "../../assets/images/light-logo.png";
 import profileImage from "../../assets/images/user/user.png";
+import LanguageSwitcher from "../../components/LanguageSwitcher";
+import { useLanguage } from "../../context/LanguageContext";
 import { ThemeContext } from "../../context/ThemeContext";
 import { useAuth } from "../../hooks/useAuth";
 
@@ -87,42 +89,86 @@ const NavBar = () => {
     activateMenu();
   }, [location.pathname, activateMenu]);
 
+  //Language Context
+  const {language} = useLanguage();
+
   // Navigation items
-  const navItems = [
-    { path: "/", label: "Início" },
-    { path: "/joblist", label: "Vagas" },
-    { path: "/companylist", label: "Empresas" },
-    { path: "/contact", label: "Contacto" },
-    { path: "/blog", label: "Blog" },
-  ];
+  const translations = {
+  pt: {
+    navItems: [
+      { path: "/", label: "Início" },
+      { path: "/joblist", label: "Vagas" },
+      { path: "/companylist", label: "Empresas" },
+      { path: "/contact", label: "Contacto" },
+      { path: "/blog", label: "Blog" },
+    ],
+    companyDropdownItems: [
+      { path: "/aboutus", label: "Sobre Nós", icon: "mdi-information-outline" },
+      {
+        path: "/privacyandpolicy",
+        label: "Privacidade & Política",
+        icon: "mdi-shield-account-outline",
+      },
+      {
+        path: "/faqs",
+        label: "Perguntas Frequentes",
+        icon: "mdi-help-circle-outline",
+      },
+    ],
+    profileDropdownItems: [
+      { path: "/myprofile", label: "Meu Perfil", icon: "mdi-account-outline" },
+      {
+        path: "/bookmarkjobs",
+        label: "Vagas Favoritas",
+        icon: "mdi-bookmark-multiple-outline",
+      },
+      {
+        path: "/managejobs",
+        label: "Minhas Candidaturas",
+        icon: "mdi-briefcase-outline",
+      },
+    ],
+  },
 
-  const companyDropdownItems = [
-    { path: "/aboutus", label: "Sobre Nós", icon: "mdi-information-outline" },
-    {
-      path: "/privacyandpolicy",
-      label: "Privacidade & Política",
-      icon: "mdi-shield-account-outline",
-    },
-    {
-      path: "/faqs",
-      label: "Perguntas Frequentes",
-      icon: "mdi-help-circle-outline",
-    },
-  ];
+  en: {
+    navItems: [
+      { path: "/", label: "Home" },
+      { path: "/joblist", label: "Jobs" },
+      { path: "/companylist", label: "Companies" },
+      { path: "/contact", label: "Contact" },
+      { path: "/blog", label: "Blog" },
+    ],
+    companyDropdownItems: [
+      { path: "/aboutus", label: "About Us", icon: "mdi-information-outline" },
+      {
+        path: "/privacyandpolicy",
+        label: "Privacy & Policy",
+        icon: "mdi-shield-account-outline",
+      },
+      {
+        path: "/faqs",
+        label: "FAQs",
+        icon: "mdi-help-circle-outline",
+      },
+    ],
+    profileDropdownItems: [
+      { path: "/myprofile", label: "My Profile", icon: "mdi-account-outline" },
+      {
+        path: "/bookmarkjobs",
+        label: "Bookmarked Jobs",
+        icon: "mdi-bookmark-multiple-outline",
+      },
+      {
+        path: "/managejobs",
+        label: "My Applications",
+        icon: "mdi-briefcase-outline",
+      },
+    ],
+  },
+};
 
-  const profileDropdownItems = [
-    { path: "/myprofile", label: "Meu Perfil", icon: "mdi-account-outline" },
-    {
-      path: "/bookmarkjobs",
-      label: "Vagas Favoritas",
-      icon: "mdi-bookmark-multiple-outline",
-    },
-    {
-      path: "/managejobs",
-      label: "Minhas Candidaturas",
-      icon: "mdi-briefcase-outline",
-    },
-  ];
+
+const t = translations[language] || translations['pt']
 
   return (
     <nav
@@ -156,8 +202,10 @@ const NavBar = () => {
           id="navbarCollapse"
         >
           <ul className="navbar-nav mx-auto navbar-center">
-            {navItems.map((item) => (
+            <LanguageSwitcher breakpoint={"md"} visibility={"none"}/>
+            {t.navItems.map((item) => (
               <NavItem key={item.path}>
+                
                 <Link className="nav-link" to={item.path}>
                   {item.label}
                 </Link>
@@ -171,7 +219,7 @@ const NavBar = () => {
                 onClick={toggleCompanyDropdown}
                 aria-expanded={companyDropdownOpen}
               >
-                Sobre Nós <div className="arrow-down"></div>
+                {language === 'pt' ? "Sobre Nós" : "About Us"} <div className="arrow-down"></div>
               </NavLink>
               <ul
                 className={classnames(
@@ -180,7 +228,7 @@ const NavBar = () => {
                 )}
                 aria-labelledby="aboutDropdown"
               >
-                {companyDropdownItems.map((item) => (
+                {t.companyDropdownItems.map((item) => (
                   <li key={item.path}>
                     <Link className="dropdown-item" to={item.path}>
                       <i className={`mdi ${item.icon} me-2`}></i>
@@ -215,6 +263,9 @@ const NavBar = () => {
               />
             </button>
           </li>
+          <div className="d-none d-md-block">
+            <LanguageSwitcher/>
+          </div>
 
           {user && (
             <>
@@ -236,14 +287,14 @@ const NavBar = () => {
                     end
                   >
                     <div className="p-3 border-bottom">
-                      <h6 className="m-0">Notificações</h6>
+                      <h6 className="m-0">{language === 'pt' ? "Notificações" : "Notifications"}</h6>
                     </div>
                     <div
                       className="px-2"
                       style={{ maxHeight: "300px", overflowY: "auto" }}
                     >
                       <div className="text-center py-3">
-                        Nenhuma notificação
+                        {language === 'pt' ? "Nenhuma notificação" : "No notifications"}
                       </div>
                     </div>
                   </DropdownMenu>
@@ -268,7 +319,7 @@ const NavBar = () => {
                       className="rounded-circle me-1"
                     />
                     <span className="d-none d-md-inline-block fw-medium">
-                      Olá, {user.name.split(" ")[0]}!
+                      {language === 'pt' ? "Olá" : "Hi" }, {user.name.split(" ")[0]}!
                     </span>
                   </DropdownToggle>
                   <DropdownMenu
@@ -295,7 +346,7 @@ const NavBar = () => {
                       className="px-2"
                       style={{ maxHeight: "300px", overflowY: "auto" }}
                     >
-                      {profileDropdownItems.map((item) => (
+                      {t.profileDropdownItems.map((item) => (
                         <DropdownItem
                           key={item.path}
                           tag={Link}
@@ -312,7 +363,7 @@ const NavBar = () => {
                         className="dropdown-item text-danger"
                       >
                         <i className="mdi mdi-logout me-2"></i>
-                        Sair
+                        {language === 'pt' ? "Sair" : "Log Out"}
                       </DropdownItem>
                     </div>
                   </DropdownMenu>
@@ -330,7 +381,7 @@ const NavBar = () => {
                   aria-label="Fazer login"
                 >
                   <i className="mdi mdi-login me-1"></i>
-                  Entrar
+                  {language === 'pt' ? "Entrar" : "Sign In"}
                 </Button>
               </Link>
             </li>

--- a/src/Layout/CommonLayout/Subscribe.js
+++ b/src/Layout/CommonLayout/Subscribe.js
@@ -3,8 +3,10 @@ import { Col, Container, Row } from "reactstrap";
 
 //Import Image
 import subscribeImg from "../../assets/images/subscribe.png";
+import { useLanguage } from "../../context/LanguageContext";
 
 const Subscribe = () => {
+  const {language} = useLanguage();
   return (
     <React.Fragment>
       <section className="bg-subscribe">
@@ -13,10 +15,10 @@ const Subscribe = () => {
             <Col lg={6}>
               <div className="text-center text-lg-start">
                 <h4 className="text-white">
-                  Receba notificações de novas vagas!
+                  {language === 'pt' ? "Receba notificações de novas vagas!" : "Receive notifications of new vacancies!"}
                 </h4>
                 <p className="text-white-50 mb-0">
-                  Inscreva-se e receba notificações de vagas relacionadas.
+                   {language === 'pt' ? "Inscreva-se e receba notificações de vagas relacionadas." : "Sign up and receive notifications of related vacancies."}
                 </p>
               </div>
             </Col>
@@ -28,14 +30,14 @@ const Subscribe = () => {
                       type="text"
                       className="form-control"
                       id="subscribe"
-                      placeholder="Digite seu e-mail"
+                      placeholder={language === 'pt' ? "Digite seu e-mail" : "Enter your email"}
                     />
                     <button
                       className="btn btn-primary"
                       type="button"
                       id="subscribebtn"
                     >
-                      Inscrever-se
+                      {language === 'pt' ? "Inscrever-se" : "Subscribe"}
                     </button>
                   </div>
                 </form>

--- a/src/components/LanguageSwitcher.js
+++ b/src/components/LanguageSwitcher.js
@@ -1,0 +1,22 @@
+import { useLanguage } from "../context/LanguageContext";
+
+const LanguageSwitcher = ({breakpoint,visibility}) => {
+  const { language, toggleLanguage } = useLanguage();
+
+  return (
+    <div className={`form-check form-switch d-${breakpoint}-${visibility}`}>
+      <input
+        className="form-check-input"
+        type="checkbox"
+        id="languageSwitch"
+        onChange={toggleLanguage}
+        checked={language === "en"}
+      />
+      <label className="form-check-label" htmlFor="languageSwitch">
+        {language === "pt" ? "PT" : "EN"}
+      </label>
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/context/LanguageContext.js
+++ b/src/context/LanguageContext.js
@@ -1,0 +1,22 @@
+import { createContext, useContext, useState } from "react";
+
+// Criação do contexto
+export const LanguageContext = createContext();
+
+// Hook personalizado para facilitar o uso
+export const useLanguage = () => useContext(LanguageContext);
+
+// Provedor
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState("pt"); // PT é padrão
+
+  const toggleLanguage = () => {
+    setLanguage((prev) => (prev === "pt" ? "en" : "pt"));
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, toggleLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,11 @@
 // reportWebVitals();
 
 import ReactDOM from "react-dom/client";
-import App from "./App";
 import { BrowserRouter } from "react-router-dom";
-import { ReactQueryProvider } from "./providers/QueryClientProvider";
+import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
+import { LanguageProvider } from "./context/LanguageContext";
+import { ReactQueryProvider } from "./providers/QueryClientProvider";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
@@ -17,7 +18,9 @@ root.render(
     <BrowserRouter basename={process.env.PUBLIC_URL}>
       <ReactQueryProvider>
         <AuthProvider>
-          <App />
+          <LanguageProvider>
+            <App />
+          </LanguageProvider>
         </AuthProvider>
       </ReactQueryProvider>
     </BrowserRouter>

--- a/src/pages/Home/Blog.js
+++ b/src/pages/Home/Blog.js
@@ -1,48 +1,93 @@
 import React from "react";
-import { Col, Row, Container } from "reactstrap";
 import { Link } from "react-router-dom";
+import { Col, Container, Row } from "reactstrap";
 
 //Importação de imagens do Blog
 import BlogImage1 from "../../assets/images/blog/img-01.jpg";
 import BlogImage2 from "../../assets/images/blog/img-02.jpg";
 import BlogImage3 from "../../assets/images/blog/img-03.jpg";
+import { useLanguage } from "../../context/LanguageContext";
 
 const Blog = () => {
-  const blog = [
-    {
-      id: 1,
-      image: BlogImage1,
-      userName: "Dirio Walls",
-      date: "01 Julho, 2021",
-      likesCount: "33",
-      commnetCount: "08",
-      blogTitle: "Como os aplicativos estão mudando o mundo da TI?",
-      blogContent:
-        "O texto final ainda não está disponível. Textos fictícios têm sido usados por diagramadores há séculos."
+  const { language } = useLanguage();
+  const translatedBlogs = {
+    pt: {
+      blog: [
+        {
+          id: 1,
+          image: BlogImage1,
+          userName: "Dirio Walls",
+          date: "01 Julho, 2021",
+          likesCount: "33",
+          commnetCount: "08",
+          blogTitle: "Como os aplicativos estão mudando o mundo da TI?",
+          blogContent:
+            "O texto final ainda não está disponível. Textos fictícios têm sido usados por diagramadores há séculos."
+        },
+        {
+          id: 2,
+          image: BlogImage2,
+          userName: "Brandon Carney",
+          date: "25 Junho, 2021",
+          likesCount: 44,
+          commnetCount: 25,
+          blogTitle: "Os aplicativos mais inteligentes para negócios?",
+          blogContent:
+            "O texto final ainda não está disponível. Textos fictícios têm sido usados por diagramadores há séculos."
+        },
+        {
+          id: 3,
+          image: BlogImage3,
+          userName: "William Mooneyhan",
+          date: "16 Março, 2021",
+          likesCount: 68,
+          commnetCount: 20,
+          blogTitle: "Como desenhar seus apps do seu jeito?",
+          blogContent:
+            "Uma desvantagem do Lorem Ipsum é que, em latim, certas letras aparecem com mais frequência do que outras."
+        }
+      ]
     },
-    {
-      id: 2,
-      image: BlogImage2,
-      userName: "Brandon Carney",
-      date: "25 Junho, 2021",
-      likesCount: 44,
-      commnetCount: 25,
-      blogTitle: "Os aplicativos mais inteligentes para negócios?",
-      blogContent:
-        "O texto final ainda não está disponível. Textos fictícios têm sido usados por diagramadores há séculos."
-    },
-    {
-      id: 3,
-      image: BlogImage3,
-      userName: "William Mooneyhan",
-      date: "16 Março, 2021",
-      likesCount: 68,
-      commnetCount: 20,
-      blogTitle: "Como desenhar seus apps do seu jeito?",
-      blogContent:
-        "Uma desvantagem do Lorem Ipsum é que, em latim, certas letras aparecem com mais frequência do que outras."
+    en: {
+      blog :[
+        {
+          id: 1,
+          image: BlogImage1,
+          userName: "Dirio Walls",
+          date: "01 July, 2021",
+          likesCount: "33",
+          commnetCount: "08",
+          blogTitle: "How Are Apps Changing the IT World?",
+          blogContent:
+            "The final text is not yet available. Placeholder texts have been used by typesetters for centuries.",
+        },
+        {
+          id: 2,
+          image: BlogImage2,
+          userName: "Brandon Carney",
+          date: "25 June, 2021",
+          likesCount: 44,
+          commnetCount: 25,
+          blogTitle: "The Smartest Apps for Business?",
+          blogContent:
+            "The final text is not yet available. Placeholder texts have been used by typesetters for centuries.",
+        },
+        {
+          id: 3,
+          image: BlogImage3,
+          userName: "William Mooneyhan",
+          date: "16 March, 2021",
+          likesCount: 68,
+          commnetCount: 20,
+          blogTitle: "How to Design Your Apps Your Own Way?",
+          blogContent:
+            "One disadvantage of Lorem Ipsum is that in Latin, certain letters appear more frequently than others.",
+        },
+      ]
     }
-  ];
+  };
+
+  const t = translatedBlogs[language] || translatedBlogs['pt']
 
   return (
     <React.Fragment>
@@ -51,15 +96,17 @@ const Blog = () => {
           <Row className="justify-content-center">
             <Col lg={6}>
               <div className="section-title text-center mb-5">
-                <h3 className="title mb-3">Dicas Rápidas de Carreira</h3>
+                <h3 className="title mb-3">{language === 'pt' ? "Dicas Rápidas de Carreira" : "Quick Career Tips"}</h3>
                 <p className="text-muted">
-                  Publique uma vaga e nos conte sobre o seu projeto. Vamos conectá-lo rapidamente com os freelancers ideais.
+                  <p className="text-muted">
+                    {language === 'pt' ? "Publique uma vaga para nos contar sobre seu projeto. Iremos conectá-lo rapidamente com os candidatos certos." : "Post a job to tell us about your project. We'll quickly connect you with the right candidates."}
+                  </p>
                 </p>
               </div>
             </Col>
           </Row>
           <Row>
-            {(blog || []).map((blogDetails, key) => (
+            {(t.blog || []).map((blogDetails, key) => (
               <Col lg={4} md={6} key={key}>
                 <div className="blog-box card p-2 mt-3">
                   <div className="blog-img position-relative overflow-hidden">
@@ -100,7 +147,7 @@ const Blog = () => {
                     </Link>
                     <p className="text-muted">{blogDetails.blogContent}</p>
                     <Link to="/blogdetails" className="form-text text-primary">
-                      Leia mais{" "}
+                      {language === 'pt' ? "Leia mais" : "Read more"}{" "}
                       <i className="mdi mdi-chevron-right align-middle"></i>
                     </Link>
                   </div>

--- a/src/pages/Home/Cta.js
+++ b/src/pages/Home/Cta.js
@@ -1,8 +1,10 @@
 import React from "react";
-import { Col, Row, Container } from "reactstrap";
 import { Link } from "react-router-dom";
+import { Col, Container, Row } from "reactstrap";
+import { useLanguage } from "../../context/LanguageContext";
 
 const Cta = () => {
+  const {language} = useLanguage();
   return (
     <React.Fragment>
       <section className="section bg-light">
@@ -11,17 +13,16 @@ const Cta = () => {
             <Col lg={7}>
               <div className="text-center">
                 <h2 className="text-primary mb-4">
-                  Explore as Nossas{" "}
-                  <span className="text-warning fw-bold">5.000+</span> Vagas
-                  Recentes
+                  {language === 'pt' ? "Explore as Nossas" : "Explore our"}{" "}
+                  <span className="text-warning fw-bold">5.000+</span> {language === 'pt' ? "Vagas Recentes" : "Latest Vacancies"}
                 </h2>
                 <p className="text-muted">
-                  Publique um trabalho para nos contar sobre o seu projeto. Nós
-                  o conectaremos rapidamente com os candidatos certos.
+                  {language === 'pt' ? "Publique uma vaga para nos contar sobre seu projeto. Iremos conectá-lo rapidamente com os candidatos certos." : "Post a job to tell us about your project. We'll quickly connect you with the right candidates."}
+                  
                 </p>
                 <div className="mt-4 pt-2">
                   <Link to="/joblist" className="btn btn-primary btn-hover">
-                    Comece Agora{" "}
+                    {language === 'pt' ? "Comece Agora" : "Get Started"}{" "}
                     <i className="uil uil-rocket align-middle ms-1"></i>
                   </Link>
                 </div>

--- a/src/pages/Home/HowItWorks.js
+++ b/src/pages/Home/HowItWorks.js
@@ -1,21 +1,23 @@
+import classnames from "classnames";
 import React, { useState } from "react";
 import {
   Col,
-  Row,
   Container,
   Nav,
   NavLink,
+  Row,
   TabContent,
   TabPane,
 } from "reactstrap";
-import classnames from "classnames";
 
 //Process Images Import
 import processImage1 from "../../assets/images/process-01.png";
 import processImage2 from "../../assets/images/process-02.png";
 import processImage3 from "../../assets/images/process-03.png";
+import { useLanguage } from "../../context/LanguageContext";
 
 const HowItWorks = () => {
+  const {language} = useLanguage();
   const [activeTab, setActiveTab] = useState("1");
 
   const tabChange = (tab) => {
@@ -28,10 +30,9 @@ const HowItWorks = () => {
           <Row className="align-items-center">
             <Col lg={6}>
               <div className="section-title me-5">
-                <h3 className="title">Como Funciona?</h3>
+                <h3 className="title">{language === 'pt' ? "Como Funciona?" : "How does it work?"}</h3>
                 <p className="text-muted">
-                  Publique um trabalho para nos contar sobre o seu projeto. Nós
-                  o conectaremos rapidamente com os candidatos certos.
+                  {language === 'pt' ? "Publique um trabalho para nos contar sobre o seu projeto. Nós o conectaremos rapidamente com os candidatos certos." : "Post a job to tell us about your project.We'll quickly connect you with the right candidates."}
                 </p>
                 <Nav className="process-menu  flex-column nav-pills">
                   <NavLink
@@ -45,11 +46,9 @@ const HowItWorks = () => {
                     <div className="d-flex">
                       <div className="number flex-shrink-0">1</div>
                       <div className="flex-grow-1 text-start ms-3">
-                        <h5 className="fs-18">Registre uma conta</h5>
+                        <h5 className="fs-18">{language === 'pt' ? "Registre uma conta" : "Register an account"}</h5>
                         <p className="text-muted mb-0">
-                          Devido ao seu uso generalizado como texto de
-                          preenchimento em layouts, a legibilidade é de grande
-                          importância.
+                          {language === 'pt' ? "Devido ao seu uso generalizado como texto de preenchimento em layouts, a legibilidade é de grande importância." : "Devido ao seu uso generalizado como texto de preenchimento em layouts, a legibilidade é de grande importância."}
                         </p>
                       </div>
                     </div>
@@ -66,10 +65,9 @@ const HowItWorks = () => {
                     <div className="d-flex">
                       <div className="number flex-shrink-0">2</div>
                       <div className="flex-grow-1 text-start ms-3">
-                        <h5 className="fs-18">Encontre seu trabalho</h5>
+                        <h5 className="fs-18">{language === 'pt' ? "Encontre seu trabalho" : "Find your job"}</h5>
                         <p className="text-muted mb-0">
-                          Existem muitas variações de passagens disponíveis, mas
-                          a maioria sofreu alguma alteração.
+                         {language === 'pt' ? " Existem muitas variações de passagens disponíveis, mas a maioria sofreu alguma alteração." : "There are many ticket variations available, but most have undergone some modification."}
                         </p>
                       </div>
                     </div>
@@ -86,10 +84,9 @@ const HowItWorks = () => {
                     <div className=" d-flex">
                       <div className="number flex-shrink-0">3</div>
                       <div className="flex-grow-1 text-start ms-3">
-                        <h5 className="fs-18">Candidate-se ao trabalho</h5>
+                        <h5 className="fs-18">{language === 'pt' ? "Candidate-se ao trabalho" : "Apply for the job"}</h5>
                         <p className="text-muted mb-0">
-                          É um fato conhecido que um leitor será distraído pelo
-                          conteúdo legível de uma página.
+                          {language === 'pt' ? "É um fato conhecido que um leitor será distraído pelo conteúdo legível de uma página.":"It's a known fact that a reader will be distracted by the readable content of a page."}
                         </p>
                       </div>
                     </div>

--- a/src/pages/Home/JobList/FeaturedJobs.js
+++ b/src/pages/Home/JobList/FeaturedJobs.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Col, Row } from "reactstrap";
 import { Link } from "react-router-dom";
+import { Col, Row } from "reactstrap";
 
 //jobImages
 import jobImage1 from "../../../assets/images/featured-job/img-01.png";
@@ -8,8 +8,10 @@ import jobImage2 from "../../../assets/images/featured-job/img-02.png";
 import jobImage3 from "../../../assets/images/featured-job/img-03.png";
 import jobImage4 from "../../../assets/images/featured-job/img-04.png";
 import JobApplicationModal from "../../../components/JobApplicationModal";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const FeaturedJobs = () => {
+  const {language} = useLanguage();
   const [modalOpen, setModalOpen] = useState(false);
   const toggleModal = () => setModalOpen(!modalOpen);
 
@@ -182,7 +184,7 @@ const FeaturedJobs = () => {
               <Col md={4}>
                 <div>
                   <p className="text-muted mb-0">
-                    <span className="text-dark">Experiência: </span>{" "}
+                    <span className="text-dark">{language === 'pt' ? "Experiência" : "Experience"}: </span>{" "}
                     {featuredJobdetails.experience}
                   </p>
                 </div>
@@ -193,7 +195,7 @@ const FeaturedJobs = () => {
                 <div>
                   <p className="text-muted mb-0">
                     <span className="text-dark">
-                      {featuredJobdetails.Notes === null ? "" : "Notas: "}
+                      {featuredJobdetails.Notes === null ? "" : language === 'pt' ? "Notas:" : "Notes:"}
                     </span>
                     {featuredJobdetails.Notes}{" "}
                   </p>
@@ -208,7 +210,7 @@ const FeaturedJobs = () => {
                     data-bs-toggle="modal"
                     className="primary-link"
                   >
-                    Inscreva-se <i className="mdi mdi-chevron-double-right"></i>
+                     {language === 'pt' ? "Inscreva-se" : "Sign up"} <i className="mdi mdi-chevron-double-right"></i>
                   </Link>
                 </div>
               </Col>
@@ -218,7 +220,7 @@ const FeaturedJobs = () => {
       ))}
       <div className="text-center mt-4 pt-2">
         <Link to="/joblist" className="btn btn-primary">
-          Ver Mais <i className="uil uil-arrow-right"></i>
+         {language === 'pt' ? "Ver Mais" : "See More"} <i className="uil uil-arrow-right"></i>
         </Link>
       </div>
       <div

--- a/src/pages/Home/JobList/Freelancer.js
+++ b/src/pages/Home/JobList/Freelancer.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Col, Row } from "reactstrap";
 import { Link } from "react-router-dom";
+import { Col, Row } from "reactstrap";
 
 //jobImages
 import jobImage1 from "../../../assets/images/featured-job/img-01.png";
@@ -8,8 +8,10 @@ import jobImage2 from "../../../assets/images/featured-job/img-02.png";
 import jobImage3 from "../../../assets/images/featured-job/img-03.png";
 import jobImage4 from "../../../assets/images/featured-job/img-04.png";
 import JobApplicationModal from "../../../components/JobApplicationModal";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const Freelancer = () => {
+  const {language} = useLanguage();
   const [modalOpen, setModalOpen] = useState(false);
   const toggleModal = () => setModalOpen(!modalOpen);
 
@@ -173,7 +175,7 @@ const Freelancer = () => {
               <Col md={4}>
                 <div>
                   <p className="text-muted mb-0">
-                    <span className="text-dark">Experiência: </span>{" "}
+                    <span className="text-dark">{language === 'pt' ? "Experiência" : "Experience"}: </span>{" "}
                     {freelancerJobdetails.experience}
                   </p>
                 </div>
@@ -184,7 +186,7 @@ const Freelancer = () => {
                 <div>
                   <p className="text-muted mb-0">
                     <span className="text-dark">
-                      {freelancerJobdetails.Notes === null ? "" : "Notas: "}
+                      {freelancerJobdetails.Notes === null ? "" : language === 'pt' ? "Notas:" : "Notes:"}
                     </span>
                     {freelancerJobdetails.Notes}{" "}
                   </p>
@@ -199,7 +201,7 @@ const Freelancer = () => {
                     data-bs-toggle="modal"
                     className="primary-link"
                   >
-                    Inscreva-se <i className="mdi mdi-chevron-double-right"></i>
+                    {language === 'pt' ? "Inscreva-se" : "Sign up"} <i className="mdi mdi-chevron-double-right"></i>
                   </Link>
                 </div>
               </Col>
@@ -209,7 +211,7 @@ const Freelancer = () => {
       ))}
       <div className="text-center mt-4 pt-2">
         <Link to="/joblist" className="btn btn-primary">
-          Ver Mais <i className="uil uil-arrow-right"></i>
+        {language === 'pt' ? "Ver Mais" : "See More"} <i className="uil uil-arrow-right"></i>
         </Link>
       </div>
 

--- a/src/pages/Home/JobList/Fulltime.js
+++ b/src/pages/Home/JobList/Fulltime.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Col, Row } from "reactstrap";
 import { Link } from "react-router-dom";
+import { Col, Row } from "reactstrap";
 
 //jobImages
 import jobImage1 from "../../../assets/images/featured-job/img-01.png";
@@ -8,8 +8,10 @@ import jobImage2 from "../../../assets/images/featured-job/img-02.png";
 import jobImage3 from "../../../assets/images/featured-job/img-03.png";
 import jobImage4 from "../../../assets/images/featured-job/img-04.png";
 import JobApplicationModal from "../../../components/JobApplicationModal";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const Fulltime = () => {
+  const {language} = useLanguage();
   const [modalOpen, setModalOpen] = useState(false);
   const toggleModal = () => setModalOpen(!modalOpen);
 
@@ -171,7 +173,7 @@ const Fulltime = () => {
               <Col md={4}>
                 <div>
                   <p className="text-muted mb-0">
-                    <span className="text-dark">Experiência: </span>{" "}
+                    <span className="text-dark">{language === 'pt' ? "Experiência" : "Experience"}: </span>{" "}
                     {fullTimeJobdetails.experience}
                   </p>
                 </div>
@@ -182,7 +184,7 @@ const Fulltime = () => {
                 <div>
                   <p className="text-muted mb-0">
                     <span className="text-dark">
-                      {fullTimeJobdetails.Notes === null ? "" : "Notas: "}
+                      {fullTimeJobdetails.Notes === null ? "" : language === 'pt' ? "Notas:" : "Notes:"}
                     </span>
                     {fullTimeJobdetails.Notes}{" "}
                   </p>
@@ -197,7 +199,7 @@ const Fulltime = () => {
                     data-bs-toggle="modal"
                     className="primary-link"
                   >
-                    Inscreva-se <i className="mdi mdi-chevron-double-right"></i>
+                    {language === 'pt' ? "Inscreva-se" : "Sign up"} <i className="mdi mdi-chevron-double-right"></i>
                   </Link>
                 </div>
               </Col>
@@ -207,7 +209,7 @@ const Fulltime = () => {
       ))}
       <div className="text-center mt-4 pt-2">
         <Link to="/joblist" className="btn btn-primary">
-          Ver Mais <i className="uil uil-arrow-right"></i>
+          {language === 'pt' ? "Ver Mais" : "See More"} <i className="uil uil-arrow-right"></i>
         </Link>
       </div>
       <div

--- a/src/pages/Home/JobList/Parttime.js
+++ b/src/pages/Home/JobList/Parttime.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Col, Row } from "reactstrap";
 import { Link } from "react-router-dom";
+import { useLanguage } from "../../../context/LanguageContext";
 
 //jobImages
 import jobImage1 from "../../../assets/images/featured-job/img-01.png";
@@ -10,6 +11,7 @@ import jobImage4 from "../../../assets/images/featured-job/img-04.png";
 import JobApplicationModal from "../../../components/JobApplicationModal";
 
 const Parttime = () => {
+  const {language} = useLanguage();
   const [modalOpen, setModalOpen] = useState(false);
   const toggleModal = () => setModalOpen(!modalOpen);
 
@@ -171,7 +173,7 @@ const Parttime = () => {
               <Col md={4}>
                 <div>
                   <p className="text-muted mb-0">
-                    <span className="text-dark">Experiência: </span>{" "}
+                    <span className="text-dark">{language === 'pt' ? "Experiência" : "Experience"}: </span>{" "}
                     {partTimeJobdetails.experience}
                   </p>
                 </div>
@@ -182,7 +184,7 @@ const Parttime = () => {
                 <div>
                   <p className="text-muted mb-0">
                     <span className="text-dark">
-                      {partTimeJobdetails.Notes === null ? "" : "Notas: "}
+                      {partTimeJobdetails.Notes === null ? "" : language === 'pt' ? "Notas:" : "Notes:"}
                     </span>
                     {partTimeJobdetails.Notes}{" "}
                   </p>
@@ -197,7 +199,7 @@ const Parttime = () => {
                     data-bs-toggle="modal"
                     className="primary-link"
                   >
-                    Inscreva-se <i className="mdi mdi-chevron-double-right"></i>
+                     {language === 'pt' ? "Inscreva-se" : "Sign up"} <i className="mdi mdi-chevron-double-right"></i>
                   </Link>
                 </div>
               </Col>
@@ -207,7 +209,7 @@ const Parttime = () => {
       ))}
       <div className="text-center mt-4 pt-2">
         <Link to="/joblist" className="btn btn-primary">
-          Ver Mais <i className="uil uil-arrow-right"></i>
+         {language === 'pt' ? "Ver Mais" : "See More"} <i className="uil uil-arrow-right"></i>
         </Link>
       </div>
 

--- a/src/pages/Home/JobList/RecentJobs.js
+++ b/src/pages/Home/JobList/RecentJobs.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Col, Row } from "reactstrap";
 import { Link } from "react-router-dom";
+import { Col, Row } from "reactstrap";
 
 //jobImages
 import jobImage1 from "../../../assets/images/featured-job/img-01.png";
@@ -8,8 +8,10 @@ import jobImage2 from "../../../assets/images/featured-job/img-02.png";
 import jobImage3 from "../../../assets/images/featured-job/img-03.png";
 import jobImage4 from "../../../assets/images/featured-job/img-04.png";
 import JobApplicationModal from "../../../components/JobApplicationModal";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const RecentJobs = () => {
+  const {language} = useLanguage();
   const [modalOpen, setModalOpen] = useState(false);
   const toggleModal = () => setModalOpen(!modalOpen);
 
@@ -200,7 +202,7 @@ const RecentJobs = () => {
               <Col md={4}>
                 <div>
                   <p className="text-muted mb-0">
-                    <span className="text-dark">Experiência: </span>{" "}
+                    <span className="text-dark">{language === 'pt' ? "Experiência" : "Experience"}: </span>{" "}
                     {recentJobDetails.experience}
                   </p>
                 </div>
@@ -211,7 +213,7 @@ const RecentJobs = () => {
                 <div>
                   <p className="text-muted mb-0">
                     <span className="text-dark">
-                      {recentJobDetails.Notes === null ? "" : "Notas: "}
+                      {recentJobDetails.Notes === null ? "" : language === 'pt' ? "Notas:" : "Notes:"}
                     </span>
                     {recentJobDetails.Notes}{" "}
                   </p>
@@ -221,7 +223,7 @@ const RecentJobs = () => {
               <Col lg={2} md={3}>
                 <div className="text-start text-md-end">
                   <Link to="#" onClick={toggleModal} className="primary-link">
-                    Inscreva-se <i className="mdi mdi-chevron-double-right"></i>
+                    {language === 'pt' ? "Inscreva-se" : "Sign up"} <i className="mdi mdi-chevron-double-right"></i>
                   </Link>
                 </div>
               </Col>
@@ -231,7 +233,7 @@ const RecentJobs = () => {
       ))}
       <div className="text-center mt-4 pt-2">
         <Link to="/joblist" className="btn btn-primary">
-          Ver Mais <i className="uil uil-arrow-right"></i>
+          {language === 'pt' ? "Ver Mais" : "See More"} <i className="uil uil-arrow-right"></i>
         </Link>
       </div>
       <div

--- a/src/pages/Home/JobList/jobList.js
+++ b/src/pages/Home/JobList/jobList.js
@@ -1,17 +1,18 @@
+import classnames from "classnames";
 import React, { useState } from "react";
 import {
-  Container,
-  Row,
   Col,
+  Container,
   Nav,
   NavItem,
   NavLink,
+  Row,
   TabContent,
   TabPane,
 } from "reactstrap";
-import classnames from "classnames";
 
 //Components Imports
+import { useLanguage } from "../../../context/LanguageContext.js";
 import FeaturedJobs from "../JobList/FeaturedJobs";
 import Freelancer from "../JobList/Freelancer.js";
 import Fulltime from "../JobList/Fulltime.js";
@@ -19,6 +20,7 @@ import Parttime from "../JobList/Parttime.js";
 import RecentJobs from "./RecentJobs";
 
 const JobList = () => {
+  const {language} = useLanguage();
   const [activeTab, setActiveTab] = useState("1");
 
   const tabChange = (tab) => {
@@ -31,10 +33,10 @@ const JobList = () => {
           <Row className="justify-content-center">
             <Col lg={6}>
               <div className="section-title text-center mb-4 pb-2">
-                <h4 className="title">Vagas Novas e Aleatórias</h4>
+                <h4 className="title">{language === 'pt' ? "Vagas Novas e Aleatórias" : "New and Random Vacancies"}</h4>
                 <p className="text-muted mb-1">
-                  Publique uma vaga para nos contar sobre seu projeto. Iremos
-                  conectá-lo rapidamente com os candidatos certos.
+                  {language === 'pt' ? "Publique uma vaga para nos contar sobre seu projeto. Iremos conectá-lo rapidamente com os candidatos certos." : "Post a job to tell us about your project. We'll quickly connect you with the right candidates."}
+                  
                 </p>
               </div>
             </Col>
@@ -57,7 +59,7 @@ const JobList = () => {
                     type="button"
                     role="tab"
                   >
-                    Recentes
+                    {language === 'pt' ? "Recentes" : "Latest"}
                   </NavLink>
                 </NavItem>
 
@@ -71,7 +73,7 @@ const JobList = () => {
                     type="button"
                     role="tab"
                   >
-                    Em Destaque
+                    {language === 'pt' ? "Em Destaque" : "Featured"}
                   </NavLink>
                 </NavItem>
                 <NavItem role="presentation">

--- a/src/pages/Home/Layout1/Section.js
+++ b/src/pages/Home/Layout1/Section.js
@@ -1,11 +1,29 @@
 import React from "react";
-import { Col, Container, Row, Form } from "reactstrap";
 import { Link } from "react-router-dom";
-import JobSearch from "../SubSection/JobSearch";
+import { Col, Container, Form, Row } from "reactstrap";
+import { useLanguage } from "../../../context/LanguageContext";
 import CountryOptions from "../SubSection/CountryOptions";
+import JobSearch from "../SubSection/JobSearch";
 import JobType from "../SubSection/JobType";
 
-const section = () => {
+const Section = () => {
+  const { language } = useLanguage();
+  const sectionText = {
+    pt: {
+      titleFirstWords: "Explore As Nossas",
+      titleSecondWords: "10.000+",
+      titleThirdWords: "Vagas Abertas",
+      paragraph: "Encontre empregos, crie currículos rastreáveis e valorize suas candidaturas."
+    },
+    en: {
+      titleFirstWords: "Explore Our",
+      titleSecondWords: "10,000+",
+      titleThirdWords: "Job Openings",
+      paragraph: "Find jobs, build trackable résumés, and enhance your applications."
+    }
+  }
+
+  const t = sectionText[language] || sectionText['pt']
   return (
     <React.Fragment>
       <section className="bg-home" id="home">
@@ -15,13 +33,12 @@ const section = () => {
             <Col lg={8}>
               <div className="text-center text-white mb-5">
                 <h1 className="display-5 fw-semibold mb-3">
-                  Explore As Nossas{" "}
-                  <span className="text-warning fw-bold">10,000+ </span>
-                  Abertas.
+                  {t.titleFirstWords}{" "}
+                  <span className="text-warning fw-bold">{t.titleSecondWords} </span>
+                  {t.titleThirdWords}
                 </h1>
                 <p className="fs-17">
-                  Encontre empregos, crie currículos rastreáveis e valorize suas
-                  candidaturas.
+                  {t.paragraph}
                 </p>
               </div>
             </Col>
@@ -54,7 +71,7 @@ const section = () => {
                       className="btn btn-primary submit-btn w-100 h-100"
                       type="submit"
                     >
-                      <i className="uil uil-search me-1"></i> Buscar Vaga
+                      <i className="uil uil-search me-1"></i> {language === 'pt' ? "Buscar Vaga" : "Search Vacancy"}
                     </button>
                   </div>
                 </Col>
@@ -67,19 +84,19 @@ const section = () => {
               <ul className="treding-keywords list-inline mb-0 text-white-50 mt-4 mt-lg-3 text-center">
                 <li className="list-inline-item text-white">
                   <i className="mdi mdi-tag-multiple-outline text-warning fs-18"></i>{" "}
-                  Palavras-chave em alta:
+                  {language === 'pt' ? "Palavras-chave em alta:" : "Trending Keywords:"}
                 </li>
                 <li className="list-inline-item">
                   <Link to="#">Design,</Link>
                 </li>
                 <li className="list-inline-item">
-                  <Link to="#">Desenvolvimento,</Link>
+                  <Link to="#">{language === 'pt' ? "Desenvolvimento," : "Development,"}</Link>
                 </li>
                 <li className="list-inline-item">
-                  <Link to="#">Gestor,</Link>
+                  <Link to="#">{language === 'pt' ? "Gestor," : "Manager,"}</Link>
                 </li>
                 <li className="list-inline-item">
-                  <Link to="#">Sênior</Link>
+                  <Link to="#">{language === 'pt' ? "Sênior" : "Senior"}</Link>
                 </li>
               </ul>
             </Col>
@@ -116,4 +133,4 @@ const section = () => {
   );
 };
 
-export default section;
+export default Section;

--- a/src/pages/Home/SubSection/CountryOptions.js
+++ b/src/pages/Home/SubSection/CountryOptions.js
@@ -1,6 +1,8 @@
 import Select from "react-select";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const CountryOptions = ({ value, onChange }) => {
+  const {language} = useLanguage();
   const countries = [
     { value: "0", label: "Afghanistan" },
     { value: "1", label: "Åland Islands" },
@@ -278,7 +280,7 @@ const CountryOptions = ({ value, onChange }) => {
   return (
     <>
       <Select
-        placeholder="Selecione um país..."
+        placeholder={language === 'pt'? "Selecione um país..." : "Select country..."}
         options={countries}
         className="choices selectForm__inner"
         value={selectedOption}

--- a/src/pages/Home/SubSection/JobSearch.js
+++ b/src/pages/Home/SubSection/JobSearch.js
@@ -1,14 +1,16 @@
 import React from "react";
 import { Input } from "reactstrap";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const JobSearch = () => {
+  const {language} = useLanguage();
   return (
     <React.Fragment>
       <Input
         type="search"
         id="job-title"
         className="form-control filter-input-box"
-        placeholder="Emprego, nome da empresa..."
+        placeholder={language === 'pt' ? "Emprego, nome da empresa..." : "Job, company name..."}
       />
     </React.Fragment>
   );

--- a/src/pages/Home/SubSection/JobType.js
+++ b/src/pages/Home/SubSection/JobType.js
@@ -1,4 +1,5 @@
 import Select from "react-select";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const JobType = ({ loading, options, value, onChange }) => {
   const colourStyles = {
@@ -21,9 +22,11 @@ const JobType = ({ loading, options, value, onChange }) => {
     onChange(selectedOption ? selectedOption.value : 0);
   };
 
+  const {language} = useLanguage();
+
   return (
     <Select
-      placeholder="Selecione a categoria..."
+      placeholder={language === 'pt' ? "Selecione a categoria..." : "Select category..."}
       options={options}
       className="choices selectForm__inner"
       value={selectedOption}

--- a/src/pages/Home/Testimonal.js
+++ b/src/pages/Home/Testimonal.js
@@ -1,46 +1,83 @@
 import React from "react";
-import { Container, Row, Col, Card, CardImg, CardBody } from "reactstrap";
-import { Swiper, SwiperSlide } from "swiper/react";
+import { Card, CardBody, CardImg, Col, Container, Row } from "reactstrap";
 import { Autoplay, Pagination } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
 
 //swiper css
 import "swiper/css";
-import "swiper/css/virtual";
-import "swiper/css/pagination";
 import "swiper/css/autoplay";
+import "swiper/css/pagination";
+import "swiper/css/virtual";
 
 //Importação de imagens
+import Instagram from "../../assets/images/logo/Instagram.svg";
 import MailChimp from "../../assets/images/logo/mailchimp.svg";
 import WordPress from "../../assets/images/logo/wordpress.svg";
-import Instagram from "../../assets/images/logo/Instagram.svg";
+import { useLanguage } from "../../context/LanguageContext";
 
 const Testimonal = () => {
-  const testimonal = [
-    {
-      id: 1,
-      image: MailChimp,
-      content:
-        "Comunicação muito bem pensada e articulada. Marcos claros, prazos definidos e trabalho rápido. Paciência. Paciência infinita. Nada de atalhos. Mesmo que o cliente esteja sendo descuidado.",
-      name: "Jeffrey Montgomery",
-      occupation: "Gerente de Produto",
+  const { language } = useLanguage();
+
+  const translatedTestimonials = {
+    pt: {
+      testimonal: [
+        {
+          id: 1,
+          image: MailChimp,
+          content:
+            "Comunicação muito bem pensada e articulada. Marcos claros, prazos definidos e trabalho rápido. Paciência. Paciência infinita. Nada de atalhos. Mesmo que o cliente esteja sendo descuidado.",
+          name: "Jeffrey Montgomery",
+          occupation: "Gerente de Produto",
+        },
+        {
+          id: 2,
+          image: WordPress,
+          content:
+            "Comunicação muito bem pensada e articulada. Marcos claros, prazos definidos e trabalho rápido. Paciência. Paciência infinita. Nada de atalhos. Mesmo que o cliente esteja sendo descuidado.",
+          name: "Rebecca Swartz",
+          occupation: "Designer Criativa",
+        },
+        {
+          id: 3,
+          image: Instagram,
+          content:
+            "Comunicação muito bem pensada e articulada. Marcos claros, prazos definidos e trabalho rápido. Paciência. Paciência infinita. Nada de atalhos. Mesmo que o cliente esteja sendo descuidado.",
+          name: "Charles Dickens",
+          occupation: "Assistente de Loja",
+        },
+      ]
     },
-    {
-      id: 2,
-      image: WordPress,
-      content:
-        "Comunicação muito bem pensada e articulada. Marcos claros, prazos definidos e trabalho rápido. Paciência. Paciência infinita. Nada de atalhos. Mesmo que o cliente esteja sendo descuidado.",
-      name: "Rebecca Swartz",
-      occupation: "Designer Criativa",
-    },
-    {
-      id: 3,
-      image: Instagram,
-      content:
-        "Comunicação muito bem pensada e articulada. Marcos claros, prazos definidos e trabalho rápido. Paciência. Paciência infinita. Nada de atalhos. Mesmo que o cliente esteja sendo descuidado.",
-      name: "Charles Dickens",
-      occupation: "Assistente de Loja",
-    },
-  ];
+    en: {
+      testimonal: [
+        {
+          id: 1,
+          image: MailChimp,
+          content:
+            "Very well-thought-out and articulated communication. Clear milestones, defined deadlines, and fast work. Patience. Infinite patience. No shortcuts. Even when the client is being careless.",
+          name: "Jeffrey Montgomery",
+          occupation: "Product Manager",
+        },
+        {
+          id: 2,
+          image: WordPress,
+          content:
+            "Very well-thought-out and articulated communication. Clear milestones, defined deadlines, and fast work. Patience. Infinite patience. No shortcuts. Even when the client is being careless.",
+          name: "Rebecca Swartz",
+          occupation: "Creative Designer",
+        },
+        {
+          id: 3,
+          image: Instagram,
+          content:
+            "Very well-thought-out and articulated communication. Clear milestones, defined deadlines, and fast work. Patience. Infinite patience. No shortcuts. Even when the client is being careless.",
+          name: "Charles Dickens",
+          occupation: "Store Assistant",
+        },
+      ]
+    }
+  };
+
+  const t = translatedTestimonials[language] || translatedTestimonials['pt']
 
   return (
     <React.Fragment>
@@ -49,11 +86,8 @@ const Testimonal = () => {
           <Row className="justify-content-center">
             <Col lg={6}>
               <div className="section-title text-center mb-4 pb-2">
-                <h3 className="title mb-3">Candidatos Satisfeitos</h3>
-                <p className="text-muted">
-                  Publique uma vaga e nos conte sobre o seu projeto. Nós o
-                  conectaremos rapidamente com os candidatos certos.
-                </p>
+                <h3 className="title mb-3">{language === 'pt' ? "Candidatos Satisfeitos" : "Satisfied Candidates"}</h3>
+                
               </div>
             </Col>
           </Row>
@@ -68,7 +102,7 @@ const Testimonal = () => {
                 pagination={{ clickable: true }}
               >
                 <div className="swiper-wrapper">
-                  {(testimonal || []).map((testimonalDetails, key) => (
+                  {(t.testimonal || []).map((testimonalDetails, key) => (
                     <SwiperSlide key={key}>
                       <Card className="testi-box">
                         <CardBody>

--- a/src/pages/Home/jobCatogaries.js
+++ b/src/pages/Home/jobCatogaries.js
@@ -1,59 +1,122 @@
-import React from "react";
-import { Col, Row, Container } from "reactstrap";
-import { Link } from "react-router-dom";
 import { Icon } from "@iconify/react";
+import React from "react";
+import { Link } from "react-router-dom";
+import { Col, Container, Row } from "reactstrap";
+import { useLanguage } from "../../context/LanguageContext";
 
 const Jobcatogaries = () => {
-  const categories = [
-    {
-      id: 1,
-      icon: "uim-layers-alt",
-      name: "TI & Software",
-      job: 2024,
+
+  const { language } = useLanguage();
+
+  const translatedCategories = {
+    pt: {
+      categories: [
+        {
+          id: 1,
+          icon: "uim-layers-alt",
+          name: "TI & Software",
+          job: 2024,
+        },
+        {
+          id: 2,
+          icon: "uim-airplay",
+          name: "Tecnologia",
+          job: 1250,
+        },
+        {
+          id: 3,
+          icon: "uim-bag",
+          name: "Governo",
+          job: 802,
+        },
+        {
+          id: 4,
+          icon: "uim-user-md",
+          name: "Finanças",
+          job: 577,
+        },
+        {
+          id: 5,
+          icon: "uim-hospital",
+          name: "Construção",
+          job: 285,
+        },
+        {
+          id: 6,
+          icon: "uim-telegram-alt",
+          name: "Telecomunicações",
+          job: 495,
+        },
+        {
+          id: 7,
+          icon: "uim-scenery",
+          name: "Design & Multimídia",
+          job: 1045,
+        },
+        {
+          id: 8,
+          icon: "uim-android-alt",
+          name: "Recursos Humanos",
+          job: 1516,
+        },
+      ]
     },
-    {
-      id: 2,
-      icon: "uim-airplay",
-      name: "Tecnologia",
-      job: 1250,
-    },
-    {
-      id: 3,
-      icon: "uim-bag",
-      name: "Governo",
-      job: 802,
-    },
-    {
-      id: 4,
-      icon: "uim-user-md",
-      name: "Finanças",
-      job: 577,
-    },
-    {
-      id: 5,
-      icon: "uim-hospital",
-      name: "Construção",
-      job: 285,
-    },
-    {
-      id: 6,
-      icon: "uim-telegram-alt",
-      name: "Telecomunicações",
-      job: 495,
-    },
-    {
-      id: 7,
-      icon: "uim-scenery",
-      name: "Design & Multimídia",
-      job: 1045,
-    },
-    {
-      id: 8,
-      icon: "uim-android-alt",
-      name: "Recursos Humanos",
-      job: 1516,
-    },
-  ];
+    en: {
+      categories :[
+        {
+          id: 1,
+          icon: "uim-layers-alt",
+          name: "IT & Software",
+          job: 2024,
+        },
+        {
+          id: 2,
+          icon: "uim-airplay",
+          name: "Technology",
+          job: 1250,
+        },
+        {
+          id: 3,
+          icon: "uim-bag",
+          name: "Government",
+          job: 802,
+        },
+        {
+          id: 4,
+          icon: "uim-user-md",
+          name: "Finance",
+          job: 577,
+        },
+        {
+          id: 5,
+          icon: "uim-hospital",
+          name: "Construction",
+          job: 285,
+        },
+        {
+          id: 6,
+          icon: "uim-telegram-alt",
+          name: "Telecommunications",
+          job: 495,
+        },
+        {
+          id: 7,
+          icon: "uim-scenery",
+          name: "Design & Multimedia",
+          job: 1045,
+        },
+        {
+          id: 8,
+          icon: "uim-android-alt",
+          name: "Human Resources",
+          job: 1516,
+        },
+      ]
+    }
+  }
+
+  const t = translatedCategories[language] || translatedCategories['pt']
+
   return (
     <React.Fragment>
       <section className="section">
@@ -61,17 +124,19 @@ const Jobcatogaries = () => {
           <Row className="justify-content-center">
             <Col lg={6}>
               <div className="section-title text-center">
-                <h3 className="title">Categorias de Emprego</h3>
+                <h3 className="title">{language === 'pt' ? "Categorias de Emprego" : "Job Categories"}</h3>
                 <p className="text-muted">
-                  Publique uma vaga para nos contar sobre o seu projeto. Iremos
-                  rapidamente conectá-lo com os candidatos ideais.
+                  {language === 'pt' ?
+                    "Publique uma vaga para nos contar sobre o seu projeto. Iremos rapidamente conectá-lo  com os candidatos ideais."
+                    : "Post a job to tell us about your project. We'll quickly connect you with the ideal candidates."
+                  }
                 </p>
               </div>
             </Col>
           </Row>
 
           <Row>
-            {(categories || []).map((item, key) => (
+            {(t.categories || []).map((item, key) => (
               <Col lg={3} md={6} className="pt-2 mt-4" key={key}>
                 <div className="popu-category-box rounded text-center">
                   <div className="popu-category-icon icons-md">
@@ -81,7 +146,7 @@ const Jobcatogaries = () => {
                     <Link to="/joblist" className="text-dark stretched-link">
                       <h5 className="fs-18">{item.name}</h5>
                     </Link>
-                    <p className="text-muted mb-0">{item.job} Vagas</p>
+                    <p className="text-muted mb-0">{item.job} {language === 'pt' ? "Vagas" : "Vancancies"}</p>
                   </div>
                 </div>
               </Col>
@@ -94,7 +159,7 @@ const Jobcatogaries = () => {
                   to="/jobscategories"
                   className="btn btn-primary btn-hover"
                 >
-                  Ver Todas as Categorias <i className="uil uil-arrow-right"></i>
+                  {language === 'pt' ? "Ver Todas as Categorias" : "See All Categories"} <i className="uil uil-arrow-right"></i>
                 </Link>
               </div>
             </Col>

--- a/src/pages/Jobs/JobList/JobSearchOptions.js
+++ b/src/pages/Jobs/JobList/JobSearchOptions.js
@@ -1,5 +1,6 @@
 import { Col, Form } from "react-bootstrap";
 import { Input, Row } from "reactstrap";
+import { useLanguage } from "../../../context/LanguageContext";
 import CountryOptions from "../../Home/SubSection/CountryOptions";
 import JobType from "../../Home/SubSection/JobType";
 
@@ -20,6 +21,8 @@ const JobSearchOptions = ({
     onSearch();
   };
 
+  const {language} = useLanguage();
+
   return (
     <div className="job-list-header">
       <Form onSubmit={handleSubmit}>
@@ -33,7 +36,7 @@ const JobSearchOptions = ({
                 value={filters.searchQuery}
                 onChange={handleInputChange}
                 className="form-control filter-input-box"
-                placeholder="Título, descrição, etc..."
+                placeholder={language === 'pt' ? "Título, descrição, etc..." : "Title, description, etc..."}
                 style={{ marginTop: "-10px" }}
               />
             </div>
@@ -60,7 +63,7 @@ const JobSearchOptions = ({
           </Col>
           <Col lg={3} md={6}>
             <button type="submit" className="btn btn-primary w-100">
-              <i className="uil uil-filter"></i> Filtrar
+              <i className="uil uil-filter"></i> {language === 'pt' ? "Filtrar" : "Filter"}
             </button>
           </Col>
         </Row>

--- a/src/pages/Jobs/JobList/JobVacancyList.js
+++ b/src/pages/Jobs/JobList/JobVacancyList.js
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
 import { useQuery } from "react-query";
+import { Link } from "react-router-dom";
+import { Col, Pagination, PaginationItem, PaginationLink, Row } from "reactstrap";
+import { useLanguage } from "../../../context/LanguageContext";
 import { getAllVacancies } from "../../../services/vacancyService";
-import { Col, Row, PaginationItem, PaginationLink, Pagination } from "reactstrap";
 
 //Images Import
 import jobImage1 from "../../../assets/images/light-logo.png";
@@ -27,6 +28,8 @@ const JobVacancyList = ({ filters }) => {
     keepPreviousData: true,
   });
 
+  const {language} = useLanguage();
+
   const handlePageChange = (newPage) => {
     if (newPage >= 0 && newPage < (data?.totalPages || 0)) {
       setPagination((prev) => ({ ...prev, page: newPage }));
@@ -45,6 +48,8 @@ const JobVacancyList = ({ filters }) => {
   if (error) {
     return <div className="text-danger">Error: {error.message}</div>;
   }
+
+  
 
   return (
     <>
@@ -159,8 +164,8 @@ const JobVacancyList = ({ filters }) => {
                 <Col md={4}>
                   <div>
                     <p className="text-muted mb-0">
-                      <span className="text-dark">Experiência: </span>
-                      {vacancy.yearsOfExperience} anos
+                      <span className="text-dark">{language === 'pt' ? "Experiência" : "Experience"}: </span>
+                      {vacancy.yearsOfExperience} {language === 'pt' ? "anos" : "years"}
                     </p>
                   </div>
                 </Col>
@@ -170,7 +175,7 @@ const JobVacancyList = ({ filters }) => {
                       to={`/jobdetails/${vacancy.id}`}
                       className="primary-link"
                     >
-                      Inscreva-se{" "}
+                      {language === 'pt' ? "Inscreva-se" : "Sign up"}{" "}
                       <i className="mdi mdi-chevron-double-right"></i>
                     </Link>
                   </div>
@@ -183,9 +188,9 @@ const JobVacancyList = ({ filters }) => {
         {/* Pagination */}
         <div className="d-flex justify-content-between align-items-center mt-4">
           <div className="text-muted">
-            Mostrando{" "}
-            <span className="fw-bold">{data?.content?.length || 0}</span> de{" "}
-            <span className="fw-bold">{data?.totalElements || 0}</span> vagas
+            {language === 'pt' ? "Mostrando" : "Showing" }{" "}
+            <span className="fw-bold">{data?.content?.length || 0}</span> {language === 'pt' ? "de" : "of"}{" "}
+            <span className="fw-bold">{data?.totalElements || 0}</span> {language === 'pt' ? "vagas" : "vacancies"}
             <select
               className="form-select form-select-sm ms-2 d-inline-block w-auto"
               value={pagination.size}
@@ -193,7 +198,7 @@ const JobVacancyList = ({ filters }) => {
             >
               {[5, 10, 20, 50].map((size) => (
                 <option key={size} value={size}>
-                  {size} por página
+                  {size} {language === 'pt' ? "por página" : "per page"}
                 </option>
               ))}
             </select>

--- a/src/pages/Jobs/JobList/Popular.js
+++ b/src/pages/Jobs/JobList/Popular.js
@@ -1,11 +1,13 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const Popular = ({ populars }) => {
+  const {language} = useLanguage();
   return (
     <React.Fragment>
       <div className="wedget-popular-title mt-4">
-        <h6>Populares</h6>
+        <h6>{language === 'pt' ? "Populares" : "Popular"}</h6>
         <ul className="list-inline">
           {(populars || []).map((detalhePopular) => (
             <li className="list-inline-item" key={detalhePopular.id}>

--- a/src/pages/Jobs/JobList/Section.js
+++ b/src/pages/Jobs/JobList/Section.js
@@ -1,8 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Col, Container, Row, Nav } from "reactstrap";
+import { Col, Container, Nav, Row } from "reactstrap";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const Section = () => {
+  const {language} = useLanguage();
   return (
     <React.Fragment>
       <section className="page-title-box">
@@ -10,7 +12,7 @@ const Section = () => {
           <Row className="justify-content-center">
             <Col md={6}>
               <div className="text-center text-white">
-                <h3 className="mb-4">Listagem de Vagas</h3>
+                <h3 className="mb-4">{language === 'pt' ? "Listagem de Vagas" : "Job Listing"}</h3>
                 <div className="page-next">
                   <Nav
                     className="d-inline-block"
@@ -18,14 +20,14 @@ const Section = () => {
                   >
                     <ol className="breadcrumb justify-content-center">
                       <li className="breadcrumb-item">
-                        <Link to="/">Ínicio</Link>
+                        <Link to="/">{language === 'pt' ? "Ínicio" : "Start"}</Link>
                       </li>
                       <li
                         className="breadcrumb-item active"
                         aria-current="page"
                       >
                         {" "}
-                        Listagem de Vagas{" "}
+                        {language === 'pt' ? "Listagem de Vagas" : "Job Listing"}{" "}
                       </li>
                     </ol>
                   </Nav>

--- a/src/pages/Jobs/JobList/Sidebar.js
+++ b/src/pages/Jobs/JobList/Sidebar.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { Button, Col, Collapse, Input, Label } from "reactstrap";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const Sidebar = () => {
   const [toggleFirst, setToggleFirst] = useState(true);
@@ -13,6 +14,8 @@ const Sidebar = () => {
   const handleOnChange = () => setIsChecked(!isChecked);
   const [isDateChecked, setIsDateChecked] = useState(true);
   const handleDateOnChange = () => setIsDateChecked(!isDateChecked);
+
+  const {language} = useLanguage();
 
   return (
     <React.Fragment>
@@ -30,7 +33,7 @@ const Sidebar = () => {
                   }}
                   role="button"
                 >
-                  Localização
+                  {language === 'pt' ? "Localização" : "Location"}
                 </Button>
               </h2>
               <Collapse isOpen={toggleFirst}>
@@ -41,7 +44,7 @@ const Sidebar = () => {
                         <Input
                           className="form-control"
                           type="search"
-                          placeholder="Pesquisar..."
+                          placeholder={language === 'pt' ? "Pesquisar..." : "Search..."}
                         />
                         <button
                           className="bg-transparent border-0 position-absolute top-50 end-0 translate-middle-y me-2"
@@ -53,7 +56,7 @@ const Sidebar = () => {
                     </div>
                     <div className="area-range slidecontainer">
                       <div className="form-label mb-4">
-                        Distância: {value}.00 km
+                        {language === 'pt' ? "Distância" : "Distance"}: {value}.00 km
                       </div>
                       <input
                         type="range"
@@ -82,7 +85,7 @@ const Sidebar = () => {
                   }}
                   role="button"
                 >
-                  Experiência de trabalho
+                  {language === 'pt' ? "Experiência de trabalho" : "Work experience"}
                 </Button>
               </h2>
               <Collapse isOpen={toggleSecond}>
@@ -98,7 +101,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="check1"
                       >
-                        Sem experiência
+                        {language === 'pt' ? "Sem experiência" : "No experience"}
                       </label>
                     </div>
                     <div className="form-check mt-2">
@@ -113,7 +116,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="check2"
                       >
-                        0-3 anos
+                        0-3 {language === 'pt' ? "anos"  : "years"}
                       </label>
                     </div>
                     <div className="form-check mt-2">
@@ -126,7 +129,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="check3"
                       >
-                        3-6 anos
+                        3-6 {language === 'pt' ? "anos"  : "years"}
                       </label>
                     </div>
                     <div className="form-check mt-2">
@@ -139,7 +142,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="check4"
                       >
-                        Mais de 6 anos
+                        {language === 'pt' ? "Mais de" : "More than"} 6 {language === 'pt' ? "anos"  : "years"}
                       </label>
                     </div>
                   </div>
@@ -158,7 +161,7 @@ const Sidebar = () => {
                   }}
                   role="button"
                 >
-                  Tipo de emprego
+                  {language === 'pt' ? "Tipo de emprego" : "Job type"}
                 </Button>
               </h2>
               <Collapse isOpen={toggleThird}>
@@ -190,7 +193,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="fulltime"
                       >
-                        Tempo integral
+                        {language === 'pt' ? "Tempo integral" : "Full time"}
                       </label>
                     </div>
                     <div className="form-check mt-2">
@@ -204,7 +207,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="internship"
                       >
-                        Estágio
+                        {language === 'pt' ? "Estágio" : "Internship"}
                       </label>
                     </div>
                     <div className="form-check mt-2">
@@ -218,7 +221,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="parttime"
                       >
-                        Meio período
+                        {language === 'pt' ? "Meio período" : "Part time"}
                       </label>
                     </div>
                   </div>
@@ -237,7 +240,7 @@ const Sidebar = () => {
                   }}
                   role="button"
                 >
-                  Data de publicação
+                  {language === 'pt' ? "Data de publicação" : "Publication date"}
                 </Button>
               </h2>
               <Collapse isOpen={toggleFourth}>
@@ -253,7 +256,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="allDates"
                       >
-                        Todas
+                        {language === 'pt' ? "Todas" : "All"}
                       </Label>
                     </div>
                     <div className="form-check mt-2">
@@ -268,7 +271,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="lastHour"
                       >
-                        Última hora
+                        {language === 'pt' ? "Última hora" : "Last hour"}
                       </Label>
                     </div>
                     <div className="form-check mt-2">
@@ -281,7 +284,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="last24"
                       >
-                        Últimas 24 horas
+                        {language === 'pt' ? "Últimas 24 horas" : "Last 24 hours"}
                       </Label>
                     </div>
                     <div className="form-check mt-2">
@@ -294,7 +297,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="last7"
                       >
-                        Últimos 7 dias
+                        {language === 'pt' ? "Últimos 7 dias" : "Last 7 days"}
                       </Label>
                     </div>
                     <div className="form-check mt-2">
@@ -307,7 +310,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="last14"
                       >
-                        Últimos 14 dias
+                        {language === 'pt' ? "Últimos 14 dias" : "Last 14 days"}
                       </Label>
                     </div>
                     <div className="form-check mt-2">
@@ -320,7 +323,7 @@ const Sidebar = () => {
                         className="form-check-label ms-2 text-muted"
                         htmlFor="last30"
                       >
-                        Últimos 30 dias
+                        {language === 'pt' ? "Últimos 30 dias" : "Last 30 days"}
                       </Label>
                     </div>
                   </div>
@@ -339,7 +342,7 @@ const Sidebar = () => {
                   }}
                   role="button"
                 >
-                  Nuvem de tags
+                  {language === 'pt' ? "Nuvem de tags" : "Cloud of tags"}
                 </Button>
               </h2>
               <Collapse isOpen={toggleFifth}>
@@ -352,10 +355,10 @@ const Sidebar = () => {
                       marketing
                     </Link>
                     <Link to="#" className="badge tag-cloud fs-13 mt-2">
-                      negócios
+                      {language === 'pt' ? "negócios" : "business"}
                     </Link>
                     <Link to="#" className="badge tag-cloud fs-13 mt-2">
-                      programador
+                      {language === 'pt' ? "programador" : "programmer"}
                     </Link>
                   </div>
                 </div>


### PR DESCRIPTION
- Implemented internationalization (i18n) context to support multiple languages (pt and en)
- Created a language switch toggle button for users to switch between Portuguese and English
- Translated all homepage content to English
- Ensured fallback language is Portuguese in case of missing keys